### PR TITLE
Add CandidateAgent prototype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8501
+CMD ["streamlit", "run", "app/main.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# LLM-Candidate-Agent
+# CandidateAgent
+
+CandidateAgent is a prototype LLM-powered resume assistant. Recruiters can chat with the agent to learn more about Nikhil Racha's experience and technical background. The app uses OpenAI's GPT models with LangChain to answer questions based on an embedded copy of the candidate's resume.
+
+## Architecture
+- **Streamlit UI** – simple chat interface
+- **LangChain** – loads and queries resume data
+- **Vector Store** – FAISS for similarity search
+- **Prompt Template** – customize the assistant's tone
+- **Dockerized** – ready for container deployment
+
+## Setup
+1. Install Python 3.10+
+2. `pip install -r requirements.txt`
+3. Set the `OPENAI_API_KEY` environment variable
+4. `streamlit run app/main.py`
+
+## Docker
+Build and run the app in Docker:
+```bash
+docker build -t candidate-agent .
+docker run -p 8501:8501 -e OPENAI_API_KEY=sk-... candidate-agent
+```
+
+## Next Steps
+- Add authentication for recruiter sessions
+- Support multiple resumes/candidates
+- Switch vector store to Chroma
+- Deploy to a cloud service for easier access

--- a/app/agent.py
+++ b/app/agent.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.chat_models import ChatOpenAI
+from langchain.chains import RetrievalQA
+
+from resume_loader import load_resume
+
+class ResumeAgent:
+    def __init__(self, resume_path: str = "data/resume.pdf", prompt_path: str = "app/prompt_template.txt"):
+        self.db = self._build_vector_store(resume_path)
+        self.chain = self._build_chain(prompt_path)
+
+    def _build_vector_store(self, resume_path: str):
+        documents = load_resume(Path(resume_path))
+        embeddings = OpenAIEmbeddings()
+        return FAISS.from_documents(documents, embeddings)
+
+    def _build_chain(self, prompt_path: str):
+        llm = ChatOpenAI(temperature=0)
+        retriever = self.db.as_retriever()
+        with open(prompt_path, 'r') as f:
+            system_prompt = f.read()
+        return RetrievalQA.from_chain_type(
+            llm=llm,
+            chain_type="stuff",
+            retriever=retriever,
+            chain_type_kwargs={"prompt": system_prompt},
+        )
+
+    def ask(self, question: str) -> str:
+        result = self.chain.run(question)
+        return result

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+import streamlit as st
+from agent import ResumeAgent
+
+st.title("CandidateAgent")
+
+# Initialize agent
+if 'agent' not in st.session_state:
+    st.session_state['agent'] = ResumeAgent()
+
+user_input = st.text_input("Ask about Nikhil Racha's experience:")
+if st.button('Submit') and user_input:
+    response = st.session_state['agent'].ask(user_input)
+    st.write(response)

--- a/app/prompt_template.txt
+++ b/app/prompt_template.txt
@@ -1,0 +1,1 @@
+You are a helpful assistant representing the candidate Nikhil Racha. Answer recruiter questions clearly and concisely, highlighting technical strengths and relevant experience. Keep responses professional and no more than a few sentences unless asked for detail.

--- a/app/resume_loader.py
+++ b/app/resume_loader.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from typing import List
+from langchain.docstore.document import Document
+import PyPDF2
+
+
+def load_resume(path: Path) -> List[Document]:
+    """Load resume PDF and return list of Documents."""
+    text = ""
+    with open(path, "rb") as f:
+        reader = PyPDF2.PdfReader(f)
+        for page in reader.pages:
+            text += page.extract_text() or ""
+    return [Document(page_content=text)]

--- a/data/resume.pdf
+++ b/data/resume.pdf
@@ -1,0 +1,38 @@
+%PDF-1.4
+%
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [3 0 R]
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/Resources <<>>
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 13
+>>
+stream
+Hello World!
+endstream
+endobj
+trailer
+<<
+/Root 1 0 R
+>>
+startxref
+506
+%%EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+langchain
+openai
+faiss-cpu
+PyPDF2


### PR DESCRIPTION
## Summary
- scaffold CandidateAgent project with Streamlit interface
- implement agent with LangChain and FAISS
- add resume loader and prompt template
- create Dockerfile and requirements
- document setup and Docker usage

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68700cd958648324989709873fe83094