### PR TITLE
Improve API key setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ CandidateAgent is a prototype LLM-powered resume assistant. Recruiters can chat 
 ## Setup
 1. Install Python 3.10+
 2. `pip install -r requirements.txt`
-3. Set the `OPENAI_API_KEY` environment variable
+3. Create a `.env` file in the project root and add your API key (this file is already listed in `.gitignore`):
+   ```
+   OPENAI_API_KEY=sk-...
+   ```
+   Alternatively export the variable in your shell with `export OPENAI_API_KEY=sk-...`.
 4. `streamlit run app/main.py`
 
 ## Docker


### PR DESCRIPTION
## Summary
- gitignore `.env` to keep API keys private
- document using a `.env` file or shell variable for `OPENAI_API_KEY`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875890385fc8324af1f20c77f6e42c6