### PR TITLE
Improve API key loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -12,14 +12,21 @@ CandidateAgent is a prototype LLM-powered resume assistant. Recruiters can chat 
 ## Setup
 1. Install Python 3.10+
 2. `pip install -r requirements.txt`
-3. Set the `OPENAI_API_KEY` environment variable
+3. Create a `.env` file in the project root and add your API key (this file is already listed in `.gitignore`):
+   ```
+   OPENAI_API_KEY=sk-...
+   ```
+   Alternatively export the variable in your shell with `export OPENAI_API_KEY=sk-...`.
 4. `streamlit run app/main.py`
+   
+   The application uses **python-dotenv** to automatically load environment
+   variables from `.env`, so the API key will be available when the app starts.
 
 ## Docker
 Build and run the app in Docker:
 ```bash
 docker build -t candidate-agent .
-docker run -p 8501:8501 -e OPENAI_API_KEY=sk-... candidate-agent
+docker run -p 8501:8501 --env-file .env candidate-agent
 ```
 
 ## Next Steps

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,8 @@
 import streamlit as st
 from agent import ResumeAgent
+from dotenv import load_dotenv
+
+load_dotenv()
 
 st.title("CandidateAgent")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ langchain
 openai
 faiss-cpu
 PyPDF2
+python-dotenv


### PR DESCRIPTION
## Summary
- add python-dotenv to requirements
- load environment variables from `.env` at startup
- document automatic loading with python-dotenv
- show `--env-file` option for Docker

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875890385fc8324af1f20c77f6e42c6