### PR TITLE
Add resume customization inputs and agent rebuild

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -6,15 +6,19 @@ from langchain.chains import RetrievalQA
 from langchain.prompts import PromptTemplate
 
 
+from langchain.docstore.document import Document
 from resume_loader import load_resume
 
 class ResumeAgent:
-    def __init__(self, resume_path: str = "data/My_Resume_Nikhil_Racha_K.pdf", prompt_path: str = "app/prompt_template.txt"):
-        self.db = self._build_vector_store(resume_path)
+    def __init__(self, resume_path: str = "data/My_Resume_Nikhil_Racha_K.pdf", prompt_path: str = "app/prompt_template.txt", resume_text: str | None = None):
+        self.db = self._build_vector_store(resume_path, resume_text)
         self.chain = self._build_chain(prompt_path)
 
-    def _build_vector_store(self, resume_path: str):
-        documents = load_resume(Path(resume_path))
+    def _build_vector_store(self, resume_path: str, resume_text: str | None = None):
+        if resume_text is not None:
+            documents = [Document(page_content=resume_text)]
+        else:
+            documents = load_resume(Path(resume_path))
         embeddings = OpenAIEmbeddings()
         return FAISS.from_documents(documents, embeddings)
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import PyPDF2
 import streamlit as st
 from agent import ResumeAgent
 from dotenv import load_dotenv
@@ -6,11 +7,41 @@ load_dotenv()
 
 st.title("CandidateAgent")
 
-# Initialize agent
-if 'agent' not in st.session_state:
-    st.session_state['agent'] = ResumeAgent()
+def pdf_to_text(file) -> str:
+    """Extract text from an uploaded PDF file."""
+    reader = PyPDF2.PdfReader(file)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text() or ""
+    return text
 
-user_input = st.text_input("Ask about Nikhil Racha's experience:")
-if st.button('Submit') and user_input:
-    response = st.session_state['agent'].ask(user_input)
-    st.write(response)
+with st.expander("Candidate Details", expanded=True):
+    with st.form(key="input_form"):
+        resume_file = st.file_uploader("Upload Resume (PDF)", type="pdf")
+        website = st.text_input("Website URL")
+        github = st.text_input("GitHub Link")
+        story = st.text_area("Personal Story")
+        prompts = st.text_area("Helpful Prompts for the Recruiter")
+        submitted = st.form_submit_button("Submit")
+
+if submitted:
+    resume_text = ""
+    if resume_file is not None:
+        resume_text = pdf_to_text(resume_file)
+    combined = "\n\n".join(filter(None, [resume_text, website, github, story, prompts]))
+
+    st.session_state['inputs'] = {
+        'website': website,
+        'github': github,
+        'story': story,
+        'prompts': prompts,
+        'resume_text': resume_text,
+    }
+    st.session_state['agent'] = ResumeAgent(resume_text=combined)
+    st.success("ResumeAgent created.")
+
+if 'agent' in st.session_state:
+    user_input = st.text_input("Ask about the candidate:")
+    if st.button('Ask') and user_input:
+        response = st.session_state['agent'].ask(user_input)
+        st.write(response)


### PR DESCRIPTION
## Summary
- build ResumeAgent from provided text or default resume
- allow uploading resume and additional candidate info in Streamlit
- rebuild vector store on submit and enable Q/A

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6875a999bad083248bf28021528902a9